### PR TITLE
Upgrade Yocto build Dockerfile

### DIFF
--- a/yocto/Dockerfile
+++ b/yocto/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG PUID
 ENV PUID=${PUID:-1000}
@@ -11,17 +11,23 @@ ENV DATADIR ${DATADIR:-/data}
 
 ENV YOCTO_ENTRYPOINT ${YOCTO_ENTRYPOINT:-/yocto-entrypoint.sh}
 
+# Avoid blocking on tzdata configuration step
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 # Install packages to build yocto and ostree packages
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get clean && apt-get update && apt-get install -y locales \
     && apt-get -q -y install \
-        nano gawk wget git-core diffstat unzip texinfo gcc-multilib g++-multilib \
-        build-essential chrpath socat libsdl1.2-dev xterm \
-        bc cpio curl iputils-ping python3 python3-gi sudo dosfstools sshpass \
-        e2fslibs-dev libgpgme11-dev \
+        gawk wget git-core diffstat unzip texinfo gcc-multilib \
+        build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
+        xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
+        pylint3 xterm \
+        \
+        g++-multilib bc cpio curl python3-gi sudo dosfstools sshpass \
         libarchive-dev libattr1-dev libcap-dev libfuse-dev libgirepository1.0-dev \
-        libsoup2.4-dev autoconf bison libtool liblzma-dev \
-        vim tmux libncurses5-dev \
+        libsoup2.4-dev autoconf bison libtool liblzma-dev e2fslibs-dev libgpgme-dev \
+        nano vim tmux libncurses5-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/* \
@@ -32,7 +38,7 @@ RUN echo "set -g mouse on" > /etc/tmux.conf
 
 # Compile and install 'OSTree' and 'repo'
 WORKDIR /home/
-ENV OSTREE_VERSION v2018.9
+ENV OSTREE_VERSION v2020.8
 RUN git clone git://github.com/ostreedev/ostree.git;branch=master \
     && (cd ostree \
         && git checkout $OSTREE_VERSION \


### PR DESCRIPTION
* Upgrade to Ubuntu 18.04
* Upgrade installed package to match to ones in the Yocto documentation
* Upgrade OSTree to 2020.8

@jvial-witekio, you may have seen the message posted on gitter by @meladon1337 concerning an issue with the Yocto build container:

```
  File "/data/yocto/.repo/repo/main.py", line 79
    file=sys.stderr)
        ^
SyntaxError: invalid syntax
  File "/data/yocto/.repo/repo/main.py", line 79
    file=sys.stderr)
        ^
SyntaxError: invalid syntax
```
I had the same error when setting up FMU. From my understanding, Ubuntu 16.04 still uses Python 2.x by default, but repo has stopped the support for this version of Python.

So the docker has been upgraded to Ubuntu 18.04, which uses Python 3 by default, and I also took the time to upgrade OSTree since I think it's good to keep it upgraded as well.

I've been able to build an image with this new container, but I didn't have time to try pushing images to Hawkbit (my build fails for another machine I've yet to finish configuring).

@jvial-witekio perhaps you could try to build and use this new docker image, since I know you are using FMU nowadays.